### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ dependencies = [
   "click<9",
   "colorama<1",
   "crash",
-  "crate[sqlalchemy]",
   "ddlgenerator<0.2",
   "frictionless[excel,json,ods,parquet,sql]<5.6",
   "fsspec[gcs,github,http,s3]==2024.3.1",
@@ -98,6 +97,7 @@ dependencies = [
   "pandas<2",
   "requests<2.32",
   "sql-formatter<0.7",
+  "sqlalchemy-cratedb",
   "sqlmakeuper<0.2",
   "urllib3<2",
 ]


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration.

## Details
The new canonical package for the SQLAlchemy CrateDB dialect on PyPI is:

> https://pypi.org/project/sqlalchemy-cratedb/
