### PR TITLE
Dependencies: Use `numpy<2` to resolve compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dependencies = [
   "pandas<2",
   "requests<2.32",
   "sql-formatter<0.7",
-  "sqlalchemy-cratedb",
+  "sqlalchemy-cratedb==0.37.0",
   "sqlmakeuper<0.2",
   "urllib3<2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dependencies = [
   "fsspec[gcs,github,http,s3]==2024.6.0",
   "json_stream<3",
   "line-protocol-parser<2",
+  "numpy<2",
   "odfpy<2",
   "pandas<2",
   "requests<2.32",


### PR DESCRIPTION
What the title says. A few Dependabot PRs have been failing.

```
ERROR: ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

- GH-69
- GH-70
- GH-71

