### PR TITLE
CI: Update to Docker Compose V2

### DIFF
--- a/.github/workflows/oci-full.yml
+++ b/.github/workflows/oci-full.yml
@@ -56,8 +56,8 @@ jobs:
           if [[ -f release/oci/full.test.yml ]]; then
             export DOCKER_BUILDKIT=1
             export COMPOSE_DOCKER_CLI_BUILD=1
-            docker-compose --file release/oci/full.test.yml build
-            docker-compose --file release/oci/full.test.yml run sut
+            docker compose --file release/oci/full.test.yml build
+            docker compose --file release/oci/full.test.yml run sut
           fi
 
   oci:

--- a/.github/workflows/oci-standard.yml
+++ b/.github/workflows/oci-standard.yml
@@ -56,8 +56,8 @@ jobs:
           if [[ -f release/oci/standard.test.yml ]]; then
             export DOCKER_BUILDKIT=1
             export COMPOSE_DOCKER_CLI_BUILD=1
-            docker-compose --file release/oci/standard.test.yml build
-            docker-compose --file release/oci/standard.test.yml run sut
+            docker compose --file release/oci/standard.test.yml build
+            docker compose --file release/oci/standard.test.yml run sut
           fi
 
   oci:

--- a/release/oci/full.test.yml
+++ b/release/oci/full.test.yml
@@ -1,4 +1,6 @@
-sut:
-  build: ../..
-  dockerfile: release/oci/full.Dockerfile
-  command: selftest.sh full
+services:
+  sut:
+    build:
+      context: ../..
+      dockerfile: release/oci/full.Dockerfile
+    command: selftest.sh full

--- a/release/oci/standard.test.yml
+++ b/release/oci/standard.test.yml
@@ -1,4 +1,6 @@
-sut:
-  build: ../..
-  dockerfile: release/oci/standard.Dockerfile
-  command: selftest.sh standard
+services:
+  sut:
+    build:
+      context: ../..
+      dockerfile: release/oci/standard.Dockerfile
+    command: selftest.sh standard


### PR DESCRIPTION
## Problem
```
docker-compose: command not found
```
Apparently, GHA phased out the Docker Compose v1 CLI.

## References
- GH-81
