### PR TITLE
Dependencies: Stop pinning `requests` to v2.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ dependencies = [
   "numpy<3",
   "odfpy<2",
   "pandas<2.4",
-  "requests<2.33",
   "sql-formatter<0.7",
   "sqlalchemy-cratedb>=0.40.1",
   "sqlmakeuper<0.2",
@@ -122,7 +121,6 @@ optional-dependencies.develop = [
   "poethepoet<1",
   "pyproject-fmt<3",
   "ruff<0.16",
-  "types-requests<2.33",
   "validate-pyproject<1",
 ]
 optional-dependencies.full = [


### PR DESCRIPTION
## About
Why needed `requests` to be pinned to v2.32?

## References
- https://github.com/daq-tools/skeem/security/dependabot/2